### PR TITLE
Match on CRs in middle of Excel-saved CSV

### DIFF
--- a/scripts/check_line_endings.sh
+++ b/scripts/check_line_endings.sh
@@ -12,10 +12,10 @@
 if [[ $1 == "csv" ]]
 then
     # echo "checking all csv files"
-    BAD_ENDINGS=$(find data -name '*.csv' -print0 | xargs -0 grep -l $'\r$')
+    BAD_ENDINGS=$(find data -name '*.csv' -print0 | xargs -0 grep -l $'\r')
 else
     # echo "checking index"
-    BAD_ENDINGS=$(git diff-index --cached -S$'\r$' --name-only HEAD)
+    BAD_ENDINGS=$(git diff-index --cached -S$'\r' --name-only HEAD)
 fi
 
 if test -z "$BAD_ENDINGS"


### PR DESCRIPTION
On my machine, Excel saves CSVs with no terminal newline and grep only matches '$' against \n, so '\r$' never matches anything. This changes the pattern to look for CRs anywhere in the file. 

Note that this will match CRs embedded in quoted fields. This may or may not be the desired behavior, but it does mean `check_line_endings.sh` and `fix-eol.sh` detect the same cases.
